### PR TITLE
Fix: freeze TemporalSmoothing conv correctly and clean up pyproject.toml deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "neuralset==0.0.2",
   "neuraltrain==0.0.2",
   "torch>=2.5.1,<2.7",
-  "numpy==2.2.6",
+  "numpy>=2.0,<3",
   "torchvision>=0.20,<0.22",
   "x_transformers==1.27.20",
   "einops",
@@ -26,7 +26,6 @@ dependencies = [
   "langdetect",
   "spacy",
   "soundfile",
-  "pip",
   "Levenshtein",
   "julius",
   "transformers"

--- a/tribev2/model.py
+++ b/tribev2/model.py
@@ -42,7 +42,7 @@ class TemporalSmoothing(BaseModelConfig):
             kernel = gaussian_kernel_1d(kernel_size=self.kernel_size, sigma=self.sigma)
             kernel = kernel.repeat(dim, 1, 1)
             conv.weight.data = kernel
-            conv.requires_grad = False
+            conv.requires_grad_(False)
         return conv
 
 


### PR DESCRIPTION
## Summary

- **`model.py`**: Replace `conv.requires_grad = False` with `conv.requires_grad_(False)`. Setting `requires_grad` directly on an `nn.Module` is a no-op — it just adds a plain Python attribute and does not affect parameter gradients. The Gaussian kernel in `TemporalSmoothing` was therefore being updated by the optimizer unintentionally. The correct API is the in-place method `requires_grad_(False)`.

- **`pyproject.toml`**: Replace hard-pinned `numpy==2.2.6` with `numpy>=2.0,<3`. Hard-pinning in a library's `pyproject.toml` causes installation conflicts for any environment that has a different NumPy version.

- **`pyproject.toml`**: Remove `pip` from runtime dependencies. `pip` is a package manager, not a library, and has no place in `dependencies`.

## Related Issues

Closes #5
Closes #6

## Test plan

- [ ] Verify `TemporalSmoothing` conv kernel is not updated during training
- [ ] Verify `pip install tribev2` succeeds alongside other packages with different NumPy versions