### PR TITLE
fix: preserve forward slashes in HF repo ID on Windows

### DIFF
--- a/tribev2/demo_utils.py
+++ b/tribev2/demo_utils.py
@@ -191,6 +191,7 @@ class TribeModel(TribeExperiment):
             Path(cache_folder).mkdir(parents=True, exist_ok=True)
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
+        checkpoint_dir_str = str(checkpoint_dir)
         checkpoint_dir = Path(checkpoint_dir)
         if checkpoint_dir.exists():
             config_path = checkpoint_dir / "config.yaml"
@@ -198,7 +199,7 @@ class TribeModel(TribeExperiment):
         else:
             from huggingface_hub import hf_hub_download
 
-            repo_id = str(checkpoint_dir)
+            repo_id = checkpoint_dir_str
             config_path = hf_hub_download(repo_id, "config.yaml")
             ckpt_path = hf_hub_download(repo_id, checkpoint_name)
         with open(config_path, "r") as f:


### PR DESCRIPTION
## Summary
Fixes #10 
On Windows, `Path("facebook/tribev2")` converts the forward slash to a backslash, producing `"facebook\tribev2"` when cast back to `str()`. This causes `huggingface_hub.errors.HFValidationError` because the Hub expects forward slashes in repo IDs.

## Changes
**`tribev2/demo_utils.py`** - `TribeModel.from_pretrained()`:
- Save the original `checkpoint_dir` string **before** converting to `pathlib.Path`
- - Use the preserved string (with forward slashes) as the HuggingFace Hub `repo_id`
```diff
+        checkpoint_dir_str = str(checkpoint_dir)
         checkpoint_dir = Path(checkpoint_dir)
         ...
-            repo_id = str(checkpoint_dir)
- +            repo_id = checkpoint_dir_str
- ```
## Testing
Verified on Windows 11 (Python 3.13):
- `str(Path("facebook/tribev2"))` -> `"facebook\\tribev2"` (bug confirmed)
- - After fix: `repo_id` correctly preserves `"facebook/tribev2"`