### PR TITLE
Raise Python requirement to 3.11 and align docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/facebookresearch/tribev2/blob/main/tribe_demo.ipynb)
 [![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc/4.0/)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 
 📄 [Paper](https://ai.meta.com/research/publications/a-foundation-model-of-vision-audition-and-language-for-in-silico-neuroscience/) ▶️ [Demo](https://aidemos.atmeta.com/tribev2/) | 🤗 [Weights](https://huggingface.co/facebook/tribev2)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tribev2"
 version = "0.1.0"
 description = "Deep multimodal brain encoding"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 authors = [{name = "Meta Platforms, Inc."}]
 


### PR DESCRIPTION
# Raise Python requirement to 3.11 and align docs

Fixes #2 
## Summary
- Update minimum Python requirement to `>=3.11` and align project metadata and docs.

## Why
- The dependency `exca >= 0.5.20` requires Python `>= 3.11`, which causes installations to fail on Python 3.10.

## Changes
- `pyproject.toml`: set `requires-python = ">=3.11"`
- `README.md`: update Python badge to show `3.11+`

> Note: Found a mention of `h5py (>=3.10.0)` in `tribev2/studies/lebel2023bold.py` — this is a package version, not a Python version requirement, so it was left unchanged.

## Files modified
- `pyproject.toml`
- `README.md`

## Testing (recommended / performed)
- Local: verified basic install and imports on Python `3.11.15`.

How to reproduce locally:
```bash
python -m venv .venv
source .venv/bin/activate
pip install -e .
python -c "import tribev2; print('import OK')"
```

## Compatibility / Impact
- Breaking change: drops support for Python 3.10. Users must upgrade to Python `>=3.11`.

## Commit message
```
chore: require Python >=3.11; update README badge
```

## Notes for reviewers
- Update CI matrix to include Python 3.11 and remove Python 3.10.
- Consider adding a short changelog entry about the Python requirement change.

---