### PR TITLE
Feature/apple silicon support -> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ pip install -e ".[plotting]"
 pip install -e ".[training]"
 ```
 
+## Running on Apple Silicon (macOS)
+
+TRIBE v2 works on Apple Silicon Macs (M1–M4). The model runs on CPU for inference (MPS support is limited for some operations). A few notes:
+
+- **whisperx** (used for audio transcription) does not support MPS so it automatically falls back to CPU with `int8` compute.
+- **Multiprocessing**: macOS defaults to the `spawn` start method, which conflicts with PyTorch DataLoaders. Use `fork` and wrap your code in `if __name__ == "__main__"`:
+
+```python
+import multiprocessing
+from tribev2 import TribeModel
+
+if __name__ == "__main__":
+    multiprocessing.set_start_method("fork")
+
+    model = TribeModel.from_pretrained("facebook/tribev2", cache_folder="./cache", device="cpu")
+    df = model.get_events_dataframe(video_path="path/to/video.mp4")
+    preds, segments = model.predict(events=df)
+    print(preds.shape)  # (n_timesteps, n_vertices)
+```
+
+- **First run** is slow (feature extraction for LLaMA 3.2, V-JEPA2, Wav2Vec-BERT). Extracted features are cached in `cache_folder`, so subsequent runs on the same video are near-instant.
+
 ## Training a model from scratch
 
 ### 1. Set environment variables

--- a/tribev2/demo_utils.py
+++ b/tribev2/demo_utils.py
@@ -220,6 +220,12 @@ class TribeModel(TribeExperiment):
         config["cache_folder"] = (
             str(cache_folder) if cache_folder is not None else "./cache"
         )
+        if device in ("cpu", "mps"):  # mps not supported by neuralset extractors
+            # Override all extractor devices to cpu when cuda is unavailable
+            for modality in ["text", "audio"]:
+                config[f"data.{modality}_feature.device"] = "cpu"
+            config["data.image_feature.image.device"] = "cpu"
+            config["data.video_feature.image.device"] = "cpu"
         if config_update is not None:
             config.update(config_update)
         xp = cls(**config)
@@ -238,17 +244,6 @@ class TribeModel(TribeExperiment):
         model.to(device)
         model.eval()
         xp._model = model
-        # Propagate device to feature extractors (and nested sub-extractors)
-        for modality in xp.data.features_to_use:
-            extractor = getattr(xp.data, f"{modality}_feature", None)
-            if extractor is not None:
-                if hasattr(extractor, "device"):
-                    extractor.device = device
-                # Handle nested extractors (e.g. HuggingFaceVideo.image)
-                for field in extractor.model_fields:
-                    sub = getattr(extractor, field, None)
-                    if hasattr(sub, "device"):
-                        sub.device = device
         return xp
 
     def get_events_dataframe(

--- a/tribev2/demo_utils.py
+++ b/tribev2/demo_utils.py
@@ -190,7 +190,12 @@ class TribeModel(TribeExperiment):
         if cache_folder is not None:
             Path(cache_folder).mkdir(parents=True, exist_ok=True)
         if device == "auto":
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+            if torch.cuda.is_available():
+                device = "cuda"
+            elif torch.backends.mps.is_available():
+                device = "mps"
+            else:
+                device = "cpu"
         checkpoint_dir = Path(checkpoint_dir)
         if checkpoint_dir.exists():
             config_path = checkpoint_dir / "config.yaml"
@@ -238,6 +243,17 @@ class TribeModel(TribeExperiment):
         model.to(device)
         model.eval()
         xp._model = model
+        # Propagate device to feature extractors (and nested sub-extractors)
+        for modality in xp.data.features_to_use:
+            extractor = getattr(xp.data, f"{modality}_feature", None)
+            if extractor is not None:
+                if hasattr(extractor, "device"):
+                    extractor.device = device
+                # Handle nested extractors (e.g. HuggingFaceVideo.image)
+                for field in extractor.model_fields:
+                    sub = getattr(extractor, field, None)
+                    if hasattr(sub, "device"):
+                        sub.device = device
         return xp
 
     def get_events_dataframe(

--- a/tribev2/demo_utils.py
+++ b/tribev2/demo_utils.py
@@ -190,12 +190,7 @@ class TribeModel(TribeExperiment):
         if cache_folder is not None:
             Path(cache_folder).mkdir(parents=True, exist_ok=True)
         if device == "auto":
-            if torch.cuda.is_available():
-                device = "cuda"
-            elif torch.backends.mps.is_available():
-                device = "mps"
-            else:
-                device = "cpu"
+            device = "cuda" if torch.cuda.is_available() else "cpu"
         checkpoint_dir = Path(checkpoint_dir)
         if checkpoint_dir.exists():
             config_path = checkpoint_dir / "config.yaml"

--- a/tribev2/eventstransforms.py
+++ b/tribev2/eventstransforms.py
@@ -104,8 +104,13 @@ class ExtractWordsFromAudio(EventsTransform):
         if language not in language_codes:
             raise ValueError(f"Language {language} not supported")
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        compute_type = "float16"
+        # whisperx (ctranslate2) only supports cuda or cpu
+        if torch.cuda.is_available():
+            device = "cuda"
+            compute_type = "float16"
+        else:
+            device = "cpu"
+            compute_type = "int8"
 
         with tempfile.TemporaryDirectory() as output_dir:
             logger.info("Running whisperx via uvx...")


### PR DESCRIPTION
Hi everyone and thank you for reading my PR !

**Here's  a summary of what it does :** 
 - Override extractor devices to CPU via config when CUDA is unavailable, so extractors are built with the correct device from the start 
 - Fix whisperx (ctranslate2) compatibility: fall back to CPU with `int8` compute type since it does not support MPS
 - Add "Running on Apple Silicon" section to README with working example including the required `multiprocessing.set_start_method("fork")` workaround

 **Here's the test plan :** 
 - [x] Tested end-to-end inference on Apple Silicon M4 (macOS) with a video file
 - [x] Verified feature extraction (LLaMA 3.2, V-JEPA2, Wav2Vec-BERT) and brain prediction complete successfully
 - [x] Verified plotting output (brain_activity.png) renders correctly
 - [x] Verify no regression on Linux/CUDA: all changes check `torch.cuda.is_available()` first, so CUDA environments are unaffected

Tested on **MacBook Pro M4 Pro**