### PR TITLE
Guard optional demo imports in package init

### DIFF
--- a/tribev2/__init__.py
+++ b/tribev2/__init__.py
@@ -4,6 +4,10 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from tribev2.demo_utils import TribeModel
+try:
+    from tribev2.demo_utils import TribeModel
+except ImportError:
+    # Optional demo dependencies may be unavailable
+    TribeModel = None
 
 __all__ = ["TribeModel"]


### PR DESCRIPTION
## Summary

Wrap `TribeModel` import in `try/except ImportError` inside `tribev2.__init__`.

## Motivation

`tribev2.demo_utils` imports several optional dependencies, so eager import during package initialization may fail even when demo functionality is not used.

## Changes

* Added guarded import for `TribeModel`
* Preserved exported symbol in `__all__`
