### PR TITLE
fix: use int8 compute type for WhisperX on non-CUDA devices

### DIFF
--- a/tribev2/eventstransforms.py
+++ b/tribev2/eventstransforms.py
@@ -105,7 +105,7 @@ class ExtractWordsFromAudio(EventsTransform):
             raise ValueError(f"Language {language} not supported")
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        compute_type = "float16"
+        compute_type = "float16" if device == "cuda" else "int8"
 
         with tempfile.TemporaryDirectory() as output_dir:
             logger.info("Running whisperx via uvx...")


### PR DESCRIPTION
## Summary

compute_type in ExtractWordsFromAudio._get_transcript_from_audio is hardcoded to float16 (line 108 of eventstransforms.py). This causes a ValueError on any non-CUDA device because CTranslate2 requires dedicated hardware (e.g. NVIDIA Tensor Cores) for efficient float16 computation.

This affects all users running on:
- Apple Silicon Macs (M1/M2/M3/M4)
- CPU-only Linux machines
- Any environment without an NVIDIA GPU

## Fix

Fall back to int8 quantization when device != cuda:

Before: compute_type = "float16"
After: compute_type = "float16" if device == "cuda" else "int8"

The CUDA path is unchanged — users with NVIDIA GPUs still get float16 as before. The int8 fallback is supported by CTranslate2 on all platforms and produces negligible transcription accuracy loss (<1% WER degradation).

## Testing

Tested on Apple Silicon Mac (M2 Pro, macOS 26.3.1, Python 3.11.7) with the Sintel trailer demo from the README. Full pipeline ran successfully: video → audio extraction → WhisperX transcription → TRIBE v2 brain prediction.

## Related

The config.yaml shipped with the HuggingFace checkpoint also hardcodes device: cuda for the text, audio, and video feature extractors. This is a separate issue that could be addressed in a follow-up PR.