### PR TITLE
Fix CPU compute type selection for Whisper inference

### DIFF
--- a/tribev2/eventstransforms.py
+++ b/tribev2/eventstransforms.py
@@ -105,7 +105,7 @@ class ExtractWordsFromAudio(EventsTransform):
             raise ValueError(f"Language {language} not supported")
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        compute_type = "float16"
+        compute_type = "float16" if device == "cuda" else "int8"
 
         with tempfile.TemporaryDirectory() as output_dir:
             logger.info("Running whisperx via uvx...")


### PR DESCRIPTION
## Summary

Set Whisper compute type dynamically based on the active device.

## Motivation

`float16` is unsupported on CPU and causes inference failure when CUDA is unavailable.

## Changes

* Use `float16` when CUDA is available
* Use `int8` when running on CPU
