### PR TITLE
Fix incorrect word timestamps for audio inputs longer than 60 seconds

### DIFF
--- a/tribev2/eventstransforms.py
+++ b/tribev2/eventstransforms.py
@@ -202,7 +202,7 @@ class ExtractWordsFromAudio(EventsTransform):
                 transcript.loc[:, k] = v
             transcript["type"] = "Word"
             transcript["language"] = self.language
-            transcript["start"] += audio_event.start + audio_event.offset
+            transcript["start"] += audio_event.start - audio_event.offset
             all_transcripts.append(transcript)
 
         if all_transcripts:


### PR DESCRIPTION
## Bug

`ExtractWordsFromAudio` produces incorrect word timestamps for any input longer than 60 seconds (the `ChunkEvents` max_duration threshold).

`ChunkEvents` splits long audio into chunks that reuse the **same WAV file** with a non-zero `offset`, e.g. for a 96s video:

| | start | offset | filepath |
|---|---|---|---|
| Chunk 1 | 0 | 0 | audio.wav |
| Chunk 2 | 60 | 60 | audio.wav |

WhisperX is called once on the full file, so word times are already relative to the file start. The existing formula:

```python
transcript["start"] += audio_event.start + audio_event.offset 
```
double-counts the offset for chunk 2 (adds 120s instead of 0), shifting words at 90s → 210s.

This also inflates the CategoricalEvent duration computed in get_loaders, causing list_segments to generate ~2× too many segments, so a 96s video produces 215 segments spanning 0–214s instead of ~96.

## Fix

```python
transcript["start"] += audio_event.start - audio_event.offset
```
This correctly converts from file-relative time to timeline-absolute time. For chunk 2 (start=60, offset=60): word at 90s → 90 + 60 − 60 = 90s ✓

Chunk 1 (start=0, offset=0) is unaffected.

## Reproduction
I ran  the events pipeline on a 96s video to confirm the fix:
```
Chunk (start=0.0, offset=0.0):
  OLD: word times 0.071s – 93.702s
  NEW: word times 0.071s – 93.702s   ← unchanged

Chunk (start=60.0, offset=60.0):
  OLD: word times 120.071s – 213.702s  ← wrong
  NEW: word times 0.071s –  93.702s   ← correct
```
The demo notebook (`tribe_demo.ipynb`) uses a 52s Sintel clip which never triggers chunking, so this bug is not visible in the default demo.
