### PR TITLE
fix: IndexError in get_topk_rois when indexing dict_keys with numpy

### DIFF
--- a/tribev2/utils.py
+++ b/tribev2/utils.py
@@ -313,6 +313,6 @@ def get_topk_rois(data: np.ndarray, hemi="both", mesh="fsaverage5", k=10) -> lis
         right_labels = get_hcp_labels(mesh=mesh, combine=False, hemi="right").keys()
         labels = [f"{l}-lh" for l in left_labels] + [f"{l}-rh" for l in right_labels]
     else:
-        labels = get_hcp_labels(mesh=mesh, combine=False, hemi=hemi).keys()
+        labels = list(get_hcp_labels(mesh=mesh, combine=False, hemi=hemi).keys())
     top_k = np.argsort(values)[::-1][:k]
     return np.array(labels)[top_k]


### PR DESCRIPTION
## What's the bug?

When calling `get_topk_rois` with the default `hemi="both"` (or any value other than `"both_separate"`), the function crashes with:

```
IndexError: too many indices for array: array is 0-dimensional, but 1 were indexed
```

## Root cause

The `else` branch assigns `labels` from a raw `.keys()` call:

```python
labels = get_hcp_labels(mesh=mesh, combine=False, hemi=hemi).keys()
```

`dict.keys()` returns a view object, not a sequence. When passed to `np.array()`, numpy wraps the entire object into a **0-dimensional** array instead of a 1D string array. Fancy-indexing that 0-d array with `top_k` then raises the `IndexError`.

Interestingly, the `both_separate` branch right above it already handles this correctly by constructing a plain Python list — the `else` branch was just missing the same treatment.

## Fix

One character change — wrap `.keys()` in `list()`:

```python
# before
labels = get_hcp_labels(mesh=mesh, combine=False, hemi=hemi).keys()

# after
labels = list(get_hcp_labels(mesh=mesh, combine=False, hemi=hemi).keys())
```

This gives numpy a proper 1D sequence it can convert to a string array and fancy-index correctly.

## Testing

Verified on a real brain encoding run with both text and video stimuli using the default `hemi="both"`. `get_topk_rois` now returns the correct top-k parcel names without error.