### PR TITLE
Optimize temporal dropout using vectorized masked_fill

### DIFF
--- a/tribev2/model.py
+++ b/tribev2/model.py
@@ -219,9 +219,8 @@ class FmriEncoderModel(nn.Module):
         elif self.config.extractor_aggregation == "sum":
             out = sum(tensors)
         if self.config.temporal_dropout > 0 and self.training:
-            for batch_idx in range(out.shape[0]):
-                mask = torch.rand(out.shape[1]) < self.config.temporal_dropout
-                out[batch_idx, mask, :] = torch.zeros_like(out[batch_idx, mask, :])
+            mask = torch.rand(out.shape[:2], device=out.device) < self.config.temporal_dropout
+            out = out.masked_fill_(mask.unsqueeze(-1), 0.0)        
         return out
 
     def transformer_forward(self, x, subject_id=None):


### PR DESCRIPTION
This PR optimizes the temporal dropout implementation in `tribev2/model.py` to remove a cross-device memory transfer and CPU bottleneck.

Currently, the dropout mask is generated using a Python `for` loop over the batch dimension, with `torch.rand` defaulting to the CPU. This breaks the CUDA execution graph for every item in the batch. 

This patch vectorizes the operation directly on the GPU using `masked_fill_`, which improves training speed and memory efficiency.

Resolves #50 