### PR TITLE
Add feature attribution maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ print(preds.shape)  # (n_timesteps, n_vertices)
 Predictions are for the "average" subject (see paper for details) and live on the **fsaverage5** cortical mesh (~20k vertices).
 They are offset by 5 seconds in the past, in order to compensate for the hemodynamic lag.
 
+Explain a prediction with modality-by-time attribution scores:
+
+```python
+attrs, segments = model.attribute(
+    events=df,
+    method="integrated_gradients",
+    target_vertices=[1234, 5678],
+    n_steps=16,
+)
+print(attrs["text"].shape)  # (n_segments, n_feature_timesteps)
+```
+
+Attribution runs on the cached text/audio/video feature timelines consumed by
+the encoder. Use `method="occlusion"` to replace temporal windows with a
+baseline and measure the prediction drop.
+
 You can also pass `text_path` or `audio_path` to `model.get_events_dataframe` — text is automatically converted to speech and transcribed to obtain word-level timings.
 
 For a full walkthrough with brain visualizations, see the [Colab demo notebook](https://colab.research.google.com/github/facebookresearch/tribev2/blob/main/tribe_demo.ipynb).

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,82 @@
+import torch
+from torch import nn
+
+from tribev2.attribution import (
+    integrated_gradients_attribution,
+    occlusion_attribution,
+    select_output,
+)
+
+
+class Batch:
+    def __init__(self, data):
+        self.data = data
+
+
+class ToyModel(nn.Module):
+    def forward(self, batch, pool_outputs=True):
+        text = batch.data["text"].sum(dim=1, keepdim=True)
+        audio = 2.0 * batch.data["audio"].sum(dim=1, keepdim=True)
+        return text + audio
+
+
+def test_select_output_reduces_to_batch_scores():
+    output = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+
+    scores = select_output(output, target_vertices=[1, 2], target_timesteps=[0, 3])
+
+    expected = output[:, [1, 2]][:, :, [0, 3]].mean(dim=(1, 2))
+    assert torch.equal(scores, expected)
+
+
+def test_integrated_gradients_returns_modality_time_scores():
+    text = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]])
+    audio = torch.tensor([[[1.0, 0.0, 2.0]]])
+    batch = Batch({"text": text, "audio": audio})
+
+    scores = integrated_gradients_attribution(
+        ToyModel(),
+        batch,
+        modalities=["text", "audio"],
+        n_steps=8,
+    )
+
+    assert torch.allclose(scores["text"], torch.tensor([[5.0 / 3, 7.0 / 3, 3.0]]))
+    assert torch.allclose(scores["audio"], torch.tensor([[2.0 / 3, 0.0, 4.0 / 3]]))
+    assert batch.data["text"] is text
+    assert batch.data["audio"] is audio
+
+
+def test_integrated_gradients_can_target_output_timestep():
+    text = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]])
+    audio = torch.zeros(1, 1, 3)
+    batch = Batch({"text": text, "audio": audio})
+
+    scores = integrated_gradients_attribution(
+        ToyModel(),
+        batch,
+        modalities=["text"],
+        target_timesteps=[2],
+        n_steps=4,
+    )
+
+    assert torch.allclose(scores["text"], torch.tensor([[0.0, 0.0, 9.0]]))
+
+
+def test_occlusion_returns_positive_drop_for_supporting_features():
+    text = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]])
+    audio = torch.tensor([[[1.0, 0.0, 2.0]]])
+    batch = Batch({"text": text, "audio": audio})
+
+    scores = occlusion_attribution(
+        ToyModel(),
+        batch,
+        modalities=["text", "audio"],
+        window=1,
+        stride=1,
+    )
+
+    assert torch.allclose(scores["text"], torch.tensor([[5.0 / 3, 7.0 / 3, 3.0]]))
+    assert torch.allclose(scores["audio"], torch.tensor([[2.0 / 3, 0.0, 4.0 / 3]]))
+    assert batch.data["text"] is text
+    assert batch.data["audio"] is audio

--- a/tribev2/__init__.py
+++ b/tribev2/__init__.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from tribev2.demo_utils import TribeModel
-
 __all__ = ["TribeModel"]
+
+
+def __getattr__(name):
+    if name == "TribeModel":
+        from tribev2.demo_utils import TribeModel
+
+        return TribeModel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tribev2/attribution.py
+++ b/tribev2/attribution.py
@@ -1,0 +1,316 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Feature attribution utilities for TRIBE v2 models.
+
+These functions operate on cached feature tensors already present in a
+``SegmentData`` batch. They do not attribute all the way back to raw words,
+waveforms, or pixels; instead, they score the text/audio/video feature timelines
+that are consumed by the fMRI encoder.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import typing as tp
+from collections.abc import Mapping
+
+import torch
+from torch import nn
+
+TargetIndex = int | slice | tp.Sequence[int] | torch.Tensor | None
+Reduction = tp.Literal["l1", "l2", "signed"]
+
+
+def select_output(
+    output: torch.Tensor,
+    target_vertices: TargetIndex = None,
+    target_timesteps: TargetIndex = None,
+) -> torch.Tensor:
+    """Reduce model output to one scalar score per batch item.
+
+    Parameters
+    ----------
+    output:
+        Tensor with shape ``(batch, vertices, timesteps)``.
+    target_vertices:
+        Optional vertex/output indices to explain. ``None`` explains the mean
+        response over all vertices.
+    target_timesteps:
+        Optional output timestep indices to explain. ``None`` explains the mean
+        response over all output timesteps.
+    """
+    if output.ndim != 3:
+        raise ValueError(f"Expected output with 3 dimensions, got {output.shape}")
+    selected = output
+    if target_vertices is not None:
+        selected = selected[:, _normalize_index(target_vertices, output.device), :]
+    if target_timesteps is not None:
+        selected = selected[:, :, _normalize_index(target_timesteps, output.device)]
+    return selected.mean(dim=tuple(range(1, selected.ndim)))
+
+
+def reduce_temporal_attribution(
+    attribution: torch.Tensor,
+    reduction: Reduction = "l1",
+    temporal_axis: int = -1,
+) -> torch.Tensor:
+    """Reduce feature attribution tensors to ``(batch, time)`` scores."""
+    if attribution.ndim < 2:
+        raise ValueError(
+            f"Expected attribution with at least 2 dimensions, got {attribution.shape}"
+        )
+    if temporal_axis < 0:
+        temporal_axis += attribution.ndim
+    if temporal_axis <= 0 or temporal_axis >= attribution.ndim:
+        raise ValueError(
+            f"temporal_axis must refer to a non-batch dimension, got {temporal_axis}"
+        )
+
+    values = attribution.movedim(temporal_axis, -1)
+    reduce_dims = tuple(range(1, values.ndim - 1))
+    if not reduce_dims:
+        return values
+    if reduction == "l1":
+        return values.abs().sum(dim=reduce_dims)
+    if reduction == "l2":
+        return values.square().sum(dim=reduce_dims).sqrt()
+    if reduction == "signed":
+        return values.sum(dim=reduce_dims)
+    raise ValueError(f"Unknown attribution reduction: {reduction}")
+
+
+def integrated_gradients_attribution(
+    model: nn.Module,
+    batch: tp.Any,
+    modalities: tp.Sequence[str],
+    *,
+    target_vertices: TargetIndex = None,
+    target_timesteps: TargetIndex = None,
+    baselines: (
+        tp.Mapping[str, torch.Tensor | float] | torch.Tensor | float | None
+    ) = None,
+    n_steps: int = 32,
+    reduction: Reduction = "l1",
+    temporal_axis: int = -1,
+    pool_outputs: bool = True,
+    eval_mode: bool = True,
+) -> dict[str, torch.Tensor]:
+    """Compute integrated gradients attribution for feature timelines.
+
+    Returns a dictionary mapping each modality to a tensor with shape
+    ``(batch, feature_timesteps)``.
+    """
+    if n_steps < 1:
+        raise ValueError("n_steps must be >= 1")
+
+    inputs = _collect_inputs(batch, modalities)
+    baseline_map = {
+        name: _baseline_for(name, tensor, baselines) for name, tensor in inputs.items()
+    }
+    grad_sums = {
+        name: torch.zeros_like(tensor, dtype=torch.float32)
+        for name, tensor in inputs.items()
+    }
+
+    with _attribution_model_context(model, eval_mode=eval_mode):
+        for step in range(1, n_steps + 1):
+            alpha = float(step) / float(n_steps)
+            scaled_inputs = {}
+            ordered_leaves = []
+            for name, tensor in inputs.items():
+                baseline = baseline_map[name]
+                scaled = baseline + (tensor - baseline) * alpha
+                scaled = scaled.detach().clone().requires_grad_(True)
+                scaled_inputs[name] = scaled
+                ordered_leaves.append(scaled)
+
+            with _override_batch_data(batch, scaled_inputs):
+                output = model(batch, pool_outputs=pool_outputs)
+                score = select_output(
+                    output,
+                    target_vertices=target_vertices,
+                    target_timesteps=target_timesteps,
+                ).sum()
+
+            grads = torch.autograd.grad(score, ordered_leaves, allow_unused=True)
+            for name, grad in zip(scaled_inputs, grads):
+                if grad is not None:
+                    grad_sums[name] += grad.detach().to(torch.float32)
+
+    attributions = {}
+    for name, tensor in inputs.items():
+        baseline = baseline_map[name]
+        values = (tensor - baseline).detach().to(torch.float32) * (
+            grad_sums[name] / float(n_steps)
+        )
+        attributions[name] = reduce_temporal_attribution(
+            values,
+            reduction=reduction,
+            temporal_axis=temporal_axis,
+        )
+    return attributions
+
+
+def occlusion_attribution(
+    model: nn.Module,
+    batch: tp.Any,
+    modalities: tp.Sequence[str],
+    *,
+    target_vertices: TargetIndex = None,
+    target_timesteps: TargetIndex = None,
+    baselines: (
+        tp.Mapping[str, torch.Tensor | float] | torch.Tensor | float | None
+    ) = None,
+    window: int = 1,
+    stride: int = 1,
+    temporal_axis: int = -1,
+    pool_outputs: bool = True,
+    eval_mode: bool = True,
+) -> dict[str, torch.Tensor]:
+    """Compute perturbation attribution by replacing temporal windows.
+
+    Positive values mean occluding that feature-time window reduced the selected
+    model response. Returns ``(batch, feature_timesteps)`` tensors.
+    """
+    if window < 1:
+        raise ValueError("window must be >= 1")
+    if stride < 1:
+        raise ValueError("stride must be >= 1")
+
+    inputs = _collect_inputs(batch, modalities)
+    baseline_map = {
+        name: _baseline_for(name, tensor, baselines) for name, tensor in inputs.items()
+    }
+
+    with _attribution_model_context(model, eval_mode=eval_mode), torch.inference_mode():
+        base_output = model(batch, pool_outputs=pool_outputs)
+        base_score = select_output(
+            base_output,
+            target_vertices=target_vertices,
+            target_timesteps=target_timesteps,
+        )
+
+        out: dict[str, torch.Tensor] = {}
+        for name, tensor in inputs.items():
+            axis = temporal_axis if temporal_axis >= 0 else tensor.ndim + temporal_axis
+            if axis <= 0 or axis >= tensor.ndim:
+                raise ValueError(
+                    f"temporal_axis must refer to a non-batch dimension, got {axis}"
+                )
+            n_timesteps = tensor.shape[axis]
+            scores = torch.zeros(
+                tensor.shape[0],
+                n_timesteps,
+                device=tensor.device,
+                dtype=torch.float32,
+            )
+            counts = torch.zeros_like(scores)
+            baseline = baseline_map[name]
+
+            for start in range(0, n_timesteps, stride):
+                stop = min(start + window, n_timesteps)
+                occluded = tensor.detach().clone()
+                occluded[_axis_slice(axis, start, stop, tensor.ndim)] = baseline[
+                    _axis_slice(axis, start, stop, tensor.ndim)
+                ]
+                with _override_batch_data(batch, {name: occluded}):
+                    occluded_output = model(batch, pool_outputs=pool_outputs)
+                    occluded_score = select_output(
+                        occluded_output,
+                        target_vertices=target_vertices,
+                        target_timesteps=target_timesteps,
+                    )
+                delta = (base_score - occluded_score).detach().to(torch.float32)
+                scores[:, start:stop] += delta[:, None]
+                counts[:, start:stop] += 1
+            out[name] = scores / counts.clamp_min(1)
+    return out
+
+
+def _collect_inputs(
+    batch: tp.Any, modalities: tp.Sequence[str]
+) -> dict[str, torch.Tensor]:
+    inputs = {}
+    for name in modalities:
+        if name not in batch.data:
+            raise KeyError(f"Modality {name!r} is not present in the batch")
+        tensor = batch.data[name]
+        if not torch.is_tensor(tensor):
+            raise TypeError(
+                f"Expected tensor for modality {name!r}, got {type(tensor)}"
+            )
+        if not torch.is_floating_point(tensor):
+            raise TypeError(
+                f"Attribution requires floating point features for {name!r}, "
+                f"got dtype {tensor.dtype}"
+            )
+        inputs[name] = tensor.detach()
+    if not inputs:
+        raise ValueError("At least one modality is required for attribution")
+    return inputs
+
+
+def _baseline_for(
+    name: str,
+    tensor: torch.Tensor,
+    baselines: tp.Mapping[str, torch.Tensor | float] | torch.Tensor | float | None,
+) -> torch.Tensor:
+    if isinstance(baselines, Mapping):
+        value = baselines.get(name, 0.0)
+    elif baselines is None:
+        value = 0.0
+    else:
+        value = baselines
+
+    if torch.is_tensor(value):
+        baseline = value.to(device=tensor.device, dtype=tensor.dtype)
+        return torch.zeros_like(tensor) + baseline
+    return torch.full_like(tensor, float(value))
+
+
+def _normalize_index(index: TargetIndex, device: torch.device) -> TargetIndex:
+    if isinstance(index, int):
+        return [index]
+    if torch.is_tensor(index):
+        return index.to(device=device)
+    return index
+
+
+def _axis_slice(axis: int, start: int, stop: int, ndim: int) -> tuple[slice, ...]:
+    idx = [slice(None)] * ndim
+    idx[axis] = slice(start, stop)
+    return tuple(idx)
+
+
+@contextlib.contextmanager
+def _override_batch_data(
+    batch: tp.Any, replacements: tp.Mapping[str, torch.Tensor]
+) -> tp.Iterator[None]:
+    original = {name: batch.data[name] for name in replacements}
+    try:
+        batch.data.update(replacements)
+        yield
+    finally:
+        batch.data.update(original)
+
+
+@contextlib.contextmanager
+def _attribution_model_context(
+    model: nn.Module, *, eval_mode: bool
+) -> tp.Iterator[None]:
+    was_training = model.training
+    requires_grad = [param.requires_grad for param in model.parameters()]
+    try:
+        if eval_mode:
+            model.eval()
+        for param in model.parameters():
+            param.requires_grad_(False)
+        yield
+    finally:
+        for param, original in zip(model.parameters(), requires_grad):
+            param.requires_grad_(original)
+        model.train(was_training)

--- a/tribev2/demo_utils.py
+++ b/tribev2/demo_utils.py
@@ -390,3 +390,106 @@ class TribeModel(TribeExperiment):
             100.0 * n_kept / max(n_samples, 1),
         )
         return preds, all_segments
+
+    def attribute(
+        self,
+        events: pd.DataFrame,
+        method: tp.Literal[
+            "integrated_gradients", "occlusion"
+        ] = "integrated_gradients",
+        modalities: tp.Sequence[str] | None = None,
+        target_vertices: int | slice | tp.Sequence[int] | torch.Tensor | None = None,
+        target_timesteps: int | slice | tp.Sequence[int] | torch.Tensor | None = None,
+        baselines: dict[str, torch.Tensor | float] | torch.Tensor | float | None = None,
+        n_steps: int = 32,
+        occlusion_window: int = 1,
+        occlusion_stride: int = 1,
+        reduction: tp.Literal["l1", "l2", "signed"] = "l1",
+        verbose: bool = True,
+    ) -> tuple[dict[str, np.ndarray], list]:
+        """Explain predictions with modality-by-time attribution scores.
+
+        Attribution is computed on cached model feature tensors for each
+        modality, not on raw pixels, waveforms, or tokens. The returned arrays
+        are shaped ``(n_segments, n_feature_timesteps)``.
+
+        Parameters
+        ----------
+        events:
+            Events DataFrame, typically produced by
+            :meth:`get_events_dataframe`.
+        method:
+            ``"integrated_gradients"`` for gradient attribution or
+            ``"occlusion"`` for perturbation attribution.
+        modalities:
+            Modalities to explain. Defaults to all available model modalities in
+            each batch.
+        target_vertices:
+            Optional fsaverage vertex/output indices to explain. ``None`` uses
+            the mean prediction over vertices.
+        target_timesteps:
+            Optional output timesteps to explain. ``None`` uses the mean
+            prediction over output timesteps.
+        baselines:
+            Optional scalar, tensor, or per-modality baseline. Defaults to zero
+            feature tensors.
+        n_steps:
+            Number of integrated-gradients interpolation steps.
+        occlusion_window:
+            Number of feature timesteps to replace for each occlusion pass.
+        occlusion_stride:
+            Step size between occlusion windows.
+        reduction:
+            How feature dimensions are reduced to temporal scores.
+        verbose:
+            If ``True`` (default), display a ``tqdm`` progress bar.
+        """
+        if self._model is None:
+            raise RuntimeError(
+                "TribeModel must be instantiated via the .from_pretrained method"
+            )
+        model = self._model
+        loader = self.data.get_loaders(events=events, split_to_build="all")["all"]
+
+        attr_chunks: dict[str, list[np.ndarray]] = {}
+        all_segments = []
+        with torch.enable_grad():
+            for batch in tqdm(loader, disable=not verbose):
+                batch = batch.to(model.device)
+                batch_segments = list(batch.segments)
+                if self.remove_empty_segments:
+                    keep = np.array([len(s.ns_events) > 0 for s in batch_segments])
+                else:
+                    keep = np.ones(len(batch_segments), dtype=bool)
+                if not keep.any():
+                    continue
+
+                scores = model.attribute(
+                    batch,
+                    method=method,
+                    modalities=modalities,
+                    target_vertices=target_vertices,
+                    target_timesteps=target_timesteps,
+                    baselines=baselines,
+                    n_steps=n_steps,
+                    occlusion_window=occlusion_window,
+                    occlusion_stride=occlusion_stride,
+                    reduction=reduction,
+                )
+                keep_tensor = torch.as_tensor(keep, device=model.device)
+                for name, values in scores.items():
+                    attr_chunks.setdefault(name, []).append(
+                        values[keep_tensor].detach().cpu().numpy()
+                    )
+                all_segments.extend(
+                    segment
+                    for segment, should_keep in zip(batch_segments, keep)
+                    if should_keep
+                )
+
+        attributions = {
+            name: np.concatenate(chunks, axis=0)
+            for name, chunks in attr_chunks.items()
+            if chunks
+        }
+        return attributions, all_segments

--- a/tribev2/model.py
+++ b/tribev2/model.py
@@ -15,6 +15,8 @@ from neuraltrain.models.common import Mlp, SubjectLayers, SubjectLayersModel
 from neuraltrain.models.transformer import TransformerEncoder
 from torch import nn
 
+from .attribution import integrated_gradients_attribution, occlusion_attribution
+
 logger = logging.getLogger(__name__)
 
 
@@ -232,3 +234,61 @@ class FmriEncoderModel(nn.Module):
             x = x + self.subject_embed(subject_id)
         x = self.encoder(x)
         return x
+
+    def attribute(
+        self,
+        batch: SegmentData,
+        method: tp.Literal[
+            "integrated_gradients", "occlusion"
+        ] = "integrated_gradients",
+        modalities: tp.Sequence[str] | None = None,
+        target_vertices: int | slice | tp.Sequence[int] | torch.Tensor | None = None,
+        target_timesteps: int | slice | tp.Sequence[int] | torch.Tensor | None = None,
+        baselines: dict[str, torch.Tensor | float] | torch.Tensor | float | None = None,
+        n_steps: int = 32,
+        occlusion_window: int = 1,
+        occlusion_stride: int = 1,
+        reduction: tp.Literal["l1", "l2", "signed"] = "l1",
+        pool_outputs: bool = True,
+        eval_mode: bool = True,
+    ) -> dict[str, torch.Tensor]:
+        """Attribute selected fMRI outputs to modality feature timelines.
+
+        The returned dictionary maps each modality to a ``(batch, time)`` tensor.
+        Integrated gradients uses feature tensors as the attribution inputs;
+        occlusion replaces temporal windows with the baseline and measures the
+        selected output change.
+        """
+        if modalities is None:
+            modalities = [
+                modality
+                for modality in self.feature_dims
+                if modality in batch.data and modality in self.projectors
+            ]
+        if method == "integrated_gradients":
+            return integrated_gradients_attribution(
+                self,
+                batch,
+                modalities=modalities,
+                target_vertices=target_vertices,
+                target_timesteps=target_timesteps,
+                baselines=baselines,
+                n_steps=n_steps,
+                reduction=reduction,
+                pool_outputs=pool_outputs,
+                eval_mode=eval_mode,
+            )
+        if method == "occlusion":
+            return occlusion_attribution(
+                self,
+                batch,
+                modalities=modalities,
+                target_vertices=target_vertices,
+                target_timesteps=target_timesteps,
+                baselines=baselines,
+                window=occlusion_window,
+                stride=occlusion_stride,
+                pool_outputs=pool_outputs,
+                eval_mode=eval_mode,
+            )
+        raise ValueError(f"Unknown attribution method: {method}")


### PR DESCRIPTION
## Summary

Adds modality-by-time attribution support for TRIBE v2 predictions.

- Introduces feature-level integrated gradients and occlusion attribution utilities.
- Adds FmriEncoderModel.attribute(...) for model-level explanations.
- Adds TribeModel.attribute(...) for high-level batch attribution over events.
- Documents the new API in the README.
- Adds focused unit tests around output targeting, integrated gradients, occlusion, and batch restoration.

The attribution operates on cached text/audio/video feature tensors consumed by the encoder rather than raw tokens, waveforms, or pixels. This keeps the feature scoped to the current extractor architecture while enabling users to inspect which modality-time regions drive selected cortical predictions.

## Validation

- python -m pytest tests\test_attribution.py
- python -m compileall -q tribev2 tests
- python -m ruff check --select E9,F tribev2\attribution.py tribev2\model.py tribev2\demo_utils.py tests\test_attribution.py

Note: a full repo-wide lint run still reports pre-existing issues in untouched files, so this PR validates the new and touched attribution paths only.