### PR TITLE
Add runtime restart warning to prevent NumPy import error

### DIFF
--- a/tribe_demo.ipynb
+++ b/tribe_demo.ipynb
@@ -42,6 +42,20 @@
     },
     {
       "cell_type": "markdown",
+      "id": "e27cab4b",
+      "metadata": {},
+      "source": [
+        "> **⚠️ Important: Restart Runtime Required**\n",
+        ">\n",
+        "> After running the installation cell above, you must **restart the Colab runtime** before continuing:\n",
+        ">\n",
+        "> `Runtime → Restart runtime`\n",
+        ">\n",
+        "> This ensures NumPy 2.2.6 loads correctly. Skipping this step causes `ImportError: cannot import name '_center'`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "id": "45e1d595",
       "metadata": {},
       "source": [

--- a/tribe_demo.ipynb
+++ b/tribe_demo.ipynb
@@ -49,9 +49,9 @@
         ">\n",
         "> After running the installation cell above, you must **restart the Colab runtime** before continuing:\n",
         ">\n",
-        "> `Runtime → Restart runtime`\n",
+        "> `Menu > Runtime > Restart runtime`\n",
         ">\n",
-        "> This ensures NumPy 2.2.6 loads correctly. Skipping this step causes `ImportError: cannot import name '_center'`."
+        "> This ensures the updated NumPy version loads correctly. Skipping this step causes `ImportError: cannot import name '_center' from 'numpy._core.umath'`."
       ]
     },
     {


### PR DESCRIPTION
## Problem
Fixes #27 

Users running the demo notebook in Google Colab encounter `ImportError: cannot import name '_center'` when importing tribev2 after installation. This happens because NumPy 2.2.6 is installed during setup, but the old NumPy binaries remain loaded in memory until the runtime is restarted.

## Solution
Added a clear warning callout immediately after the installation cell that:
- Instructs users to restart the Colab runtime before continuing
- Explains why the restart is necessary (NumPy version update)
- Shows the exact error message they'll encounter if they skip this step

The warning is placed in a blockquote format to make it visually distinct and impossible to miss.

## Testing
- Verified the warning renders correctly in Jupyter/VS Code notebook viewer
- Confirmed the markdown formatting displays properly