### PR TITLE
Use int8 compute_type for WhisperX on non-CUDA devices

### DIFF
--- a/tribev2/eventstransforms.py
+++ b/tribev2/eventstransforms.py
@@ -105,7 +105,7 @@ class ExtractWordsFromAudio(EventsTransform):
             raise ValueError(f"Language {language} not supported")
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        compute_type = "float16"
+        compute_type = "float16" if device == "cuda" else "int8"
 
         with tempfile.TemporaryDirectory() as output_dir:
             logger.info("Running whisperx via uvx...")


### PR DESCRIPTION
`ExtractWordsFromAudio._get_transcript_from_audio` hardcodes `compute_type = "float16"` for the WhisperX subprocess regardless of device (`tribev2/eventstransforms.py:107-108`):

```python
device = "cuda" if torch.cuda.is_available() else "cpu"
compute_type = "float16"
```

faster-whisper (via ctranslate2) refuses float16 on CPU and raises:

```
ValueError: Requested float16 compute type, but the target device or backend do not support efficient float16 computation.
```

Anyone without an NVIDIA GPU hits this when calling `get_events_dataframe()` on text or audio inputs (text goes through TTS → WhisperX too), which blocks `model.predict()` end-to-end on CPU-only environments.

The fix mirrors the `device` selection one line up — keep `float16` on CUDA, fall back to `int8` on CPU. `int8` is what faster-whisper recommends for CPU per their README.

Repro on a CPU-only box:

```python
from tribev2 import TribeModel
m = TribeModel.from_pretrained("facebook/tribev2")
m.get_events_dataframe(text_path="some_text.txt")  # raises before this patch
```

CUDA users are unaffected. Verified locally on WSL2 / `torch==2.6.0+cpu`: WhisperX large-v3 returned the expected word timings, and a full text-mode `model.predict()` completed end-to-end (output shape `(n_timesteps, 20484)` on fsaverage5, matching the model card). I haven't run the `[test]` extra's pytest suite — happy to if useful. CLA signed.