### PR TITLE
Use a safe YAML loader for pretrained configs while preserving tuple support

### DIFF
--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,76 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import textwrap
+
+import pytest
+import yaml
+
+from tribev2.config_utils import TribeConfigLoader, load_config
+
+
+def test_load_config_accepts_python_tuple_tag(tmp_path):
+    """The published facebook/tribev2 config uses !!python/tuple; we must
+    keep loading it as an actual tuple to stay backward compatible."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent("""\
+            workdir:
+              excludes: !!python/tuple
+                - __pycache__
+                - .git
+            data:
+              study:
+                path: .
+            """),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert isinstance(config["workdir"]["excludes"], tuple)
+    assert config["workdir"]["excludes"] == ("__pycache__", ".git")
+    assert config["data"]["study"]["path"] == "."
+
+
+def test_load_config_handles_plain_yaml(tmp_path):
+    """Configs without any Python-specific tags must still load cleanly."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent("""\
+            data:
+              study:
+                path: .
+            infra:
+              folder: /tmp/out
+            average_subjects: true
+            """),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config["data"]["study"]["path"] == "."
+    assert config["infra"]["folder"] == "/tmp/out"
+    assert config["average_subjects"] is True
+
+
+def test_loader_rejects_python_object_new_tags():
+    """The whole point of the change: arbitrary Python object construction
+    via !!python/object/new:* must be rejected."""
+    payload = 'cmd: !!python/object/new:os.system ["echo hacked"]\n'
+
+    with pytest.raises(yaml.constructor.ConstructorError):
+        yaml.load(payload, Loader=TribeConfigLoader)
+
+
+def test_loader_rejects_python_name_tags():
+    """!!python/name lookups (another arbitrary-import vector) must also
+    be rejected."""
+    payload = "cmd: !!python/name:os.system\n"
+
+    with pytest.raises(yaml.constructor.ConstructorError):
+        yaml.load(payload, Loader=TribeConfigLoader)

--- a/tribev2/config_utils.py
+++ b/tribev2/config_utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Safer YAML loading for TRIBE config files.
+
+The pretrained-model loader used to call ``yaml.load`` with
+``yaml.UnsafeLoader``, which constructs arbitrary Python objects from
+YAML tags. That allows ``!!python/object/new:os.system [...]``-style
+payloads to execute code at load time.
+
+This module exposes ``load_config`` which uses a ``yaml.SafeLoader``
+subclass that explicitly opts in to ``!!python/tuple``, the only
+Python-specific tag known to appear in published TRIBE config files.
+All other Python-specific tags (``!!python/object``,
+``!!python/object/new``, ``!!python/name``, ``!!python/module``, …) are
+rejected by the safe base class.
+"""
+
+from pathlib import Path
+
+import yaml
+from exca import ConfDict
+
+
+class TribeConfigLoader(yaml.SafeLoader):
+    """Safe YAML loader for TRIBE configs with explicit tuple support."""
+
+
+def _construct_python_tuple(loader: yaml.Loader, node: yaml.Node) -> tuple:
+    return tuple(loader.construct_sequence(node))
+
+
+TribeConfigLoader.add_constructor(
+    "tag:yaml.org,2002:python/tuple",
+    _construct_python_tuple,
+)
+
+
+def load_config(path: str | Path) -> ConfDict:
+    """Load a TRIBE config YAML safely and return a ConfDict."""
+    with open(path, "r", encoding="utf-8") as f:
+        return ConfDict(yaml.load(f, Loader=TribeConfigLoader))

--- a/tribev2/demo_utils.py
+++ b/tribev2/demo_utils.py
@@ -15,10 +15,11 @@ import pandas as pd
 import pydantic
 import requests
 import torch
-import yaml
 from einops import rearrange
-from exca import ConfDict, TaskInfra
+from exca import TaskInfra
 from tqdm import tqdm
+
+from tribev2.config_utils import load_config
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -201,8 +202,7 @@ class TribeModel(TribeExperiment):
             repo_id = str(checkpoint_dir)
             config_path = hf_hub_download(repo_id, "config.yaml")
             ckpt_path = hf_hub_download(repo_id, checkpoint_name)
-        with open(config_path, "r") as f:
-            config = ConfDict(yaml.load(f, Loader=yaml.UnsafeLoader))
+        config = load_config(config_path)
         for modality in ["text", "audio", "video"]:
             config[f"data.{modality}_feature.infra.folder"] = cache_folder
             config[f"data.{modality}_feature.infra.cluster"] = cluster


### PR DESCRIPTION
## Summary

This PR hardens pretrained-config loading in `TribeModel.from_pretrained()`.

Today the code reads `config.yaml` with `yaml.UnsafeLoader`:

```python
# tribev2/demo_utils.py:205
config = ConfDict(yaml.load(f, Loader=yaml.UnsafeLoader))
```

`UnsafeLoader` constructs arbitrary Python objects from YAML tags such as
`!!python/object/new:os.system [...]`, which means a malicious or
tampered `config.yaml` (local file or downloaded from a Hub repo) can
execute code at load time.

This PR replaces that call with a `yaml.SafeLoader` subclass that
explicitly opts in to **only** the `!!python/tuple` tag, which is the
single Python-specific tag known to be used by published TRIBE configs.
All other Python-specific tags (`python/object`, `python/object/new`,
`python/name`, `python/module`, …) are rejected by the safe base class.

## Changes

- Add `tribev2/config_utils.py` with a `TribeConfigLoader` (SafeLoader
  subclass) and a `load_config()` helper.
- Replace the unsafe call site in `tribev2/demo_utils.py`.
- Add regression tests in `tests/test_config_utils.py` covering:
  - loading the existing `!!python/tuple` pattern as a real `tuple`,
  - loading a config with no Python-specific tags,
  - rejecting `!!python/object/new:os.system [...]` payloads,
  - rejecting `!!python/name:*` lookups.

## Why a custom subclass instead of `yaml.safe_load`

A drop-in `yaml.safe_load(f)` is what most lints suggest, but it would
break loading the currently published `facebook/tribev2` config because
the existing config uses the `!!python/tuple` tag. The `SafeLoader`
subclass is the smallest change that keeps the existing config working
while shutting the door on arbitrary code execution. The included tests
encode both halves of that contract.

## Test plan

```bash
pytest -q tests/test_config_utils.py
```