### PR TITLE
fix: Windows compatibility in from_pretrained

### DIFF
--- a/tribev2/demo_utils.py
+++ b/tribev2/demo_utils.py
@@ -198,11 +198,26 @@ class TribeModel(TribeExperiment):
         else:
             from huggingface_hub import hf_hub_download
 
-            repo_id = str(checkpoint_dir)
+            repo_id = checkpoint_dir.as_posix()
             config_path = hf_hub_download(repo_id, "config.yaml")
             ckpt_path = hf_hub_download(repo_id, checkpoint_name)
+        class _WindowsCompatLoader(yaml.UnsafeLoader):
+            pass
+
+        def _posixpath_constructor(loader, node):
+            args = loader.construct_sequence(node, deep=True)
+            return Path(*args)
+
+        for _tag in (
+            "tag:yaml.org,2002:python/object/apply:pathlib.PosixPath",
+            "tag:yaml.org,2002:python/object/apply:pathlib.WindowsPath",
+            "tag:yaml.org,2002:python/object/new:pathlib.PosixPath",
+            "tag:yaml.org,2002:python/object/new:pathlib.WindowsPath",
+        ):
+            _WindowsCompatLoader.yaml_constructors[_tag] = _posixpath_constructor
+
         with open(config_path, "r") as f:
-            config = ConfDict(yaml.load(f, Loader=yaml.UnsafeLoader))
+            config = ConfDict(yaml.load(f, Loader=_WindowsCompatLoader))
         for modality in ["text", "audio", "video"]:
             config[f"data.{modality}_feature.infra.folder"] = cache_folder
             config[f"data.{modality}_feature.infra.cluster"] = cluster


### PR DESCRIPTION
## Summary

`TribeModel.from_pretrained()` fails on Windows with two separate errors. This PR fixes both.

### Bug 1 — Invalid repo_id due to Windows path separator

`Path("facebook/tribev2")` on Windows stringifies to `facebook\tribev2` (backslash), which is rejected by `hf_hub_download` as an invalid repo ID.

**Fix:** use `.as_posix()` instead of `str()` to always produce forward slashes.

### Bug 2 — `PosixPath` cannot be instantiated on Windows

`config.yaml` was serialised on Linux and contains `!!python/object/apply:pathlib.PosixPath` YAML tags. Loading it with `yaml.UnsafeLoader` on Windows raises:

```
NotImplementedError: cannot instantiate 'PosixPath' on your system
```

**Fix:** register a custom YAML constructor directly in `yaml_constructors` (checked before multi-constructors) that maps both `PosixPath` and `WindowsPath` tags to `pathlib.Path`, which resolves correctly on any platform.

## Test

Verified on Windows 11 with Python 3.12, CUDA 12.4, RTX 4050:

```python
from tribev2 import TribeModel
model = TribeModel.from_pretrained("facebook/tribev2", cache_folder="./cache")
# Loads successfully — no errors
```

## Notes for reviewer

- No behaviour change on Linux/macOS; the custom constructor produces the same `Path` objects as the original code would have.
- `WindowsPath` and the `python/object/new:` variants are also covered defensively.