### PR TITLE
fix: cap exca to restore a working clean install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ authors = [{name = "Meta Platforms, Inc."}]
 dependencies = [
   "neuralset==0.0.2",
   "neuraltrain==0.0.2",
+  # neuralset 0.0.2 references exca.steps.base.NoValue, which exca removed in
+  # 0.5.26 (moved to exca.steps.identity). Cap exca until neuralset is updated.
+  "exca>=0.5.20,<0.5.26",
   "torch>=2.5.1,<2.7",
   "numpy==2.2.6",
   "torchvision>=0.20,<0.22",


### PR DESCRIPTION
## Summary

A clean install of `tribev2` currently fails at import time because of an `exca` API change. This caps `exca` to a compatible range so a fresh install works again, and declares `exca` as an explicit dependency since the package imports it directly.

Closes #65 (also addresses the install failures reported in #2 and #27's environment).

## Root cause

`neuralset==0.0.2` (the pinned version) references `exca.steps.base.NoValue` in `neuralset/events/study.py`:

```python
def run(self, value: tp.Any = exca.steps.base.NoValue()) -> tp.Any:
```

`exca` exposed `NoValue` under `exca.steps.base` (re-exported from `exca.steps.backends`) up to and including `0.5.25`. In `0.5.26` the symbol was moved to `exca.steps.identity` and the re-export was dropped. Because `neuralset==0.0.2` only constrains `exca>=0.5.20`, a fresh install resolves the latest `exca` (0.5.26) and fails:

```
AttributeError: module 'exca.steps.base' has no attribute 'NoValue'
  File ".../neuralset/events/study.py", line 255, in StudyLoader
    def run(self, value: tp.Any = exca.steps.base.NoValue()) -> tp.Any:
```

`tribev2` also imports `exca` directly (`from exca import ConfDict, TaskInfra` in `main.py` and `demo_utils.py`) without declaring it, so the version it gets is left entirely to transitive resolution.

## Change

```toml
"neuralset==0.0.2",
"neuraltrain==0.0.2",
# neuralset 0.0.2 references exca.steps.base.NoValue, which exca removed in
# 0.5.26 (moved to exca.steps.identity). Cap exca until neuralset is updated.
"exca>=0.5.20,<0.5.26",
```

No source changes. Bumping `neuralset`/`neuraltrain` to a newer release is not a viable alternative here: every published version after 0.0.2 (0.0.3 through 0.2.2) removes `AddText` from `neuralset.events.transforms`, which `tribev2/demo_utils.py` imports, so a version bump trades this error for an `ImportError`. Capping `exca` keeps the code unchanged.

## Verification

Reproduced and fixed in a clean Python 3.12 virtualenv.

Before (current `main`, resolves exca 0.5.26):

```
$ python -c "from tribev2.demo_utils import TribeModel"
AttributeError: module 'exca.steps.base' has no attribute 'NoValue'
```

After (this branch, resolves exca 0.5.25):

```
$ pip show exca | grep Version
Version: 0.5.25
$ python -c "from tribev2.demo_utils import TribeModel; print('IMPORT_OK')"
IMPORT_OK
```

## Note

This is a compatibility cap, not a permanent fix. The cleaner resolution is to publish a `neuralset` release that targets the current `exca` API; once that exists, the cap can be relaxed. Until then this restores a working install for everyone.
